### PR TITLE
Fix slice identification

### DIFF
--- a/atom_tools/__init__.py
+++ b/atom_tools/__init__.py
@@ -1,4 +1,4 @@
 """
 A cli, classes and functions for converting an atom slice to a different format
 """
-__version__ = '0.5.2'
+__version__ = '0.5.3'

--- a/atom_tools/cli/application.py
+++ b/atom_tools/cli/application.py
@@ -114,7 +114,7 @@ class Application(BaseApplication):
         io = event.io
 
         loggers = []
-        loggers += command.loggers
+        loggers += command.loggers  # type: ignore
 
         handler = IOHandler(io)
         handler.setFormatter(IOFormatter())

--- a/atom_tools/cli/commands/command.py
+++ b/atom_tools/cli/commands/command.py
@@ -1,13 +1,10 @@
 # pylint: disable-all
 from __future__ import annotations
 
-from typing import ClassVar
-
 from cleo.commands.command import Command as BaseCommand
 
 
 class Command(BaseCommand):
-    loggers: ClassVar[list[str]] = ['atom_tools.cli.commands.filter']
 
     def handle(self):
         pass

--- a/atom_tools/cli/commands/convert.py
+++ b/atom_tools/cli/commands/convert.py
@@ -69,7 +69,8 @@ class ConvertCommand(Command):
     ]
     help = """The convert command converts an atom slice to a different format.
 Currently supports creating an OpenAPI 3.x document based on a usages slice."""
-    loggers = ['atom_tools.lib.converter', 'atom_tools.lib.regex_utils', 'atom_tools.lib.slices']
+    loggers = ['atom_tools.lib.converter', 'atom_tools.lib.regex_utils', 'atom_tools.lib.slices',
+               'atom_tools.lib.utils']
 
     def handle(self):
         """

--- a/atom_tools/cli/commands/query_endpoints.py
+++ b/atom_tools/cli/commands/query_endpoints.py
@@ -57,8 +57,9 @@ class QueryEndpointsCommand(Command):
             'Only display names; do not include path and line numbers.',
         )
     ]
-    help = """The query command can be used to return results directly to the console. """
-    loggers = ['atom_tools.lib.converter', 'atom_tools.lib.regex_utils', 'atom_tools.lib.slices']
+    help = """The query command can be used to return endpoint results directly to the console. """
+    loggers = ['atom_tools.lib.converter', 'atom_tools.lib.regex_utils', 'atom_tools.lib.slices',
+               'atom_tools.lib.utils']
 
     def handle(self):
         """
@@ -74,8 +75,10 @@ class QueryEndpointsCommand(Command):
         )
         if not (result := converter.endpoints_to_openapi('')):
             logging.warning('No results produced!')
-        line_filter = ()
-        if self.option('filter-lines'):
-            line_filter = get_ln_range(self.option('filter-lines'))
-        output = output_endpoints(result, self.option('sparse'), line_filter)
-        print(output)
+            print('')
+        else:
+            line_filter = ()
+            if self.option('filter-lines'):
+                line_filter = get_ln_range(self.option('filter-lines'))
+            output = output_endpoints(result, self.option('sparse'), line_filter)
+            print(output)

--- a/atom_tools/cli/commands/validate_lines.py
+++ b/atom_tools/cli/commands/validate_lines.py
@@ -2,6 +2,7 @@
 """
 Line validation command for the atom-tools CLI.
 """
+import logging
 import os
 import pathlib
 import sys
@@ -10,6 +11,9 @@ from cleo.helpers import option
 
 from atom_tools.cli.commands.command import Command
 from atom_tools.lib.validator import LineValidator
+
+
+logger = logging.getLogger(__name__)
 
 
 class ValidateLinesCommand(Command):
@@ -72,7 +76,8 @@ class ValidateLinesCommand(Command):
 
     ]
     help = """Validate source file line numbers in an atom usages or reachables slice."""
-    loggers = ['atom_tools.lib.validator', 'atom_tools.lib.regex_utils', 'atom_tools.lib.slices']
+    loggers = ['atom_tools.lib.validator', 'atom_tools.lib.regex_utils', 'atom_tools.lib.slices',
+               'atom_tools.lib.utils']
 
     def handle(self):
         """

--- a/atom_tools/lib/slices.py
+++ b/atom_tools/lib/slices.py
@@ -97,9 +97,9 @@ def import_slice(filename: str | Path) -> Tuple[Dict, str, str]:
             elif 'django' in raw_content:
                 custom_attr = 'django'
             content = json.loads(raw_content)
-        if content.get('objectSlices'):
+        if 'objectSlices' in content:
             slice_type = 'usages'
-        if content.get('reachables'):
+        elif 'reachables' in content:
             slice_type = 'reachables'
     except (json.decoder.JSONDecodeError, UnicodeDecodeError):
         logger.warning(

--- a/atom_tools/lib/validator.py
+++ b/atom_tools/lib/validator.py
@@ -13,6 +13,7 @@ from atom_tools.lib.slices import AtomSlice
 from atom_tools.lib.regex_utils import ValidationRegexCollection
 from atom_tools.lib.utils import export_json, remove_duplicates_list
 
+
 logger = logging.getLogger(__name__)
 regex: ValidationRegexCollection = ValidationRegexCollection()
 operator_map: Dict[str, List[str]] = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atom-tools"
-version = "0.5.2"
+version = "0.5.3"
 description = "Collection of tools for use with AppThreat/atom."
 authors = [
   { name = "Caroline Russell", email = "caroline@appthreat.dev" },


### PR DESCRIPTION
When slices were empty, atom-tools was indicating they were of an unidentified type. This PR corrects that.