### PR TITLE
fix(converter): fix KeyError in merge_operations due to operator prec…

### DIFF
--- a/atom_tools/__init__.py
+++ b/atom_tools/__init__.py
@@ -1,4 +1,4 @@
 """
 A cli, classes and functions for converting an atom slice to a different format
 """
-__version__ = '0.8.5'
+__version__ = '0.8.6'

--- a/atom_tools/lib/converter.py
+++ b/atom_tools/lib/converter.py
@@ -1327,7 +1327,7 @@ def merge_operations(op1: Dict, op2: Dict) -> Dict:
         dict: The merged dictionary of operations.
     """
     for k, v in op2.items():
-        if v and not op1.get(k) or op1[k] == {}:
+        if v and (not op1.get(k) or op1[k] == {}):
             op1[k] = v
         elif k == 'parameters' and v:
             op1[k] = merge_params(op1[k], v)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atom-tools"
-version = "0.8.5"
+version = "0.8.6"
 description = "Collection of tools for use with AppThreat/atom."
 authors = [
   { name = "Caroline Russell", email = "caroline@appthreat.dev" },


### PR DESCRIPTION

v and not op1.get(k) or op1[k] == {} evaluated as (v and not op1.get(k)) or (op1[k] == {}). When v is falsy (e.g. empty parameters list) and the key is absent in op1, op1[k] raises KeyError: parameters. Adding parentheses ensures op1[k] is only evaluated when v is truthy.