### PR TITLE
feat: add Rust converter that reads rusi reports into OpenAPI paths

### DIFF
--- a/atom_tools/lib/converter.py
+++ b/atom_tools/lib/converter.py
@@ -21,6 +21,7 @@ from atom_tools.lib.regex_utils import (
 )
 from atom_tools.lib.slices import AtomSlice
 from atom_tools.lib.ruby_converter import convert as ruby_convert
+from atom_tools.lib.rust_converter import convert as rust_convert
 from atom_tools.lib.scala_converter import convert as scala_convert
 
 logger = logging.getLogger(__name__)
@@ -333,6 +334,8 @@ class OpenAPI:
             return ruby_convert(self.usages)
         if self.usages.origin_type in ("scala", "sbt"):
             return scala_convert(self.usages, self.semantics)
+        if self.usages.origin_type in ("rs", "rust"):
+            return rust_convert(self.usages)
         methods = self._process_methods()
         methods = self.methods_to_endpoints(methods)
         self.target_line_nums = self._identify_target_line_nums(methods)

--- a/atom_tools/lib/rust_converter.py
+++ b/atom_tools/lib/rust_converter.py
@@ -1,0 +1,297 @@
+"""
+Rust converter helper.
+
+Consumes a rusi report (produced by the `rusi` analyzer shipped in
+`cdxgen/cdxgen-plugins-bin` v2.4.0+) and produces an OpenAPI paths dict
+in the same shape that the JVM-style processing in
+``atom_tools.lib.converter`` does for other languages.
+
+Rusi's `api_endpoints` array already carries the framework, HTTP method,
+path (with prefixes from nested routers / scopes / mounts composed in),
+handler qualified name, path/query parameters, request-body type, and
+response type. This module just translates those records into the
+OpenAPI shape atom-tools' callers expect.
+
+Path placeholders are normalised across the three supported frameworks:
+* axum's ``:id``,
+* actix's ``{id}``,
+* rocket's ``<id>``,
+
+all become OpenAPI's ``{id}``.
+
+Rust types from parameter and body / response positions are mapped to
+OpenAPI schemas. Common scalars, ``Option<T>``, ``Vec<T>``, and the
+framework JSON wrappers are recognised; custom types are emitted as a
+``$ref`` pointing at ``#/components/schemas/<TypeName>`` so downstream
+tooling can still match by type name even when the field-level schema
+is not (yet) available.
+"""
+import re
+from typing import Dict, Optional
+
+from atom_tools.lib.slices import AtomSlice
+
+
+# Map of recognised Rust scalar types to OpenAPI schema dicts. Anything
+# not in here is treated as either a known wrapper (Option/Vec/Json) or
+# a custom type that becomes a $ref.
+_RUST_SCALAR_SCHEMA: Dict[str, Dict] = {
+    "i8": {"type": "integer", "format": "int32"},
+    "i16": {"type": "integer", "format": "int32"},
+    "i32": {"type": "integer", "format": "int32"},
+    "i64": {"type": "integer", "format": "int64"},
+    "i128": {"type": "integer"},
+    "isize": {"type": "integer", "format": "int64"},
+    "u8": {"type": "integer", "format": "int32"},
+    "u16": {"type": "integer", "format": "int32"},
+    "u32": {"type": "integer", "format": "int64"},
+    "u64": {"type": "integer", "format": "int64"},
+    "u128": {"type": "integer"},
+    "usize": {"type": "integer", "format": "int64"},
+    "f32": {"type": "number", "format": "float"},
+    "f64": {"type": "number", "format": "double"},
+    "bool": {"type": "boolean"},
+    "char": {"type": "string"},
+    "String": {"type": "string"},
+    "str": {"type": "string"},
+    "&str": {"type": "string"},
+}
+
+# Path-placeholder patterns. Rusi emits the framework-native placeholder
+# verbatim, so we look for each shape and normalise to ``{name}``.
+#   axum:   ``:id``
+#   rocket: ``<id>`` (also ``<id..>`` for catch-all segments)
+#   actix:  ``{id}`` (already correct — left alone)
+_PLACEHOLDER_AXUM = re.compile(r":([A-Za-z_][A-Za-z0-9_]*)")
+_PLACEHOLDER_ROCKET = re.compile(r"<([A-Za-z_][A-Za-z0-9_]*)(?:\.\.)?>")
+
+
+def normalize_path(path: str) -> str:
+    """Convert framework-native path placeholders to OpenAPI ``{name}``.
+
+    Idempotent on actix-style paths (which already use ``{name}``).
+    """
+    if not path:
+        return ""
+    path = _PLACEHOLDER_AXUM.sub(r"{\1}", path)
+    path = _PLACEHOLDER_ROCKET.sub(r"{\1}", path)
+    return path
+
+
+def rust_type_to_schema(type_name: str) -> Dict:
+    """Map a Rust type expression to an OpenAPI schema object.
+
+    Recognises common scalars and the most-frequent wrappers
+    (``Option<T>``, ``Vec<T>``, framework ``Json<T>``). Custom types
+    become a ``$ref`` so downstream consumers can match on the type
+    name even when its field structure isn't (yet) emitted.
+    """
+    if not type_name:
+        return {"type": "object"}
+    name = type_name.strip()
+
+    # Strip leading reference / lifetime tokens that occasionally land
+    # in signature text (e.g. ``&'static str``).
+    if name.startswith("&"):
+        stripped = name.lstrip("&").lstrip()
+        if stripped.startswith("'"):
+            # Drop a lifetime token like ``'static``.
+            parts = stripped.split(None, 1)
+            stripped = parts[1] if len(parts) > 1 else ""
+        if stripped:
+            return rust_type_to_schema(stripped)
+        return {"type": "string"}
+
+    # ``Option<T>`` → schema for T with the OpenAPI ``nullable`` flag.
+    if match := re.fullmatch(r"Option\s*<\s*(.+)\s*>", name):
+        inner = rust_type_to_schema(match.group(1))
+        inner["nullable"] = True
+        return inner
+
+    # ``Vec<T>`` → OpenAPI array of T.
+    if match := re.fullmatch(r"Vec\s*<\s*(.+)\s*>", name):
+        return {"type": "array", "items": rust_type_to_schema(match.group(1))}
+
+    # Framework JSON wrappers (axum::Json<T>, actix_web::web::Json<T>,
+    # rocket::serde::json::Json<T>, plain Json<T>). Unwrap and recurse.
+    if match := re.fullmatch(
+        r"(?:axum::|actix_web::|rocket::serde::json::|web::)?Json\s*<\s*(.+)\s*>",
+        name,
+    ):
+        return rust_type_to_schema(match.group(1))
+
+    # serde_json::Value → free-form JSON object.
+    if name in ("serde_json::Value", "Value"):
+        return {"type": "object"}
+
+    if name in _RUST_SCALAR_SCHEMA:
+        return dict(_RUST_SCALAR_SCHEMA[name])
+
+    # ``str`` / ``&str`` variants the lifetime-stripping above didn't
+    # catch (e.g. concatenated tokens from rusi's ToTokenStream output).
+    if name.endswith("str") or name.endswith("staticstr"):
+        return {"type": "string"}
+
+    # Fall through: custom type → $ref. Strip any module path so the
+    # schema name matches what downstream tooling typically expects.
+    schema_name = name.rsplit("::", 1)[-1]
+    return {"$ref": f"#/components/schemas/{schema_name}"}
+
+
+def _parameter_schema(type_name: str) -> Dict:
+    """Schema for a path/query parameter.
+
+    Same mapping as :func:`rust_type_to_schema` but pulls the
+    ``nullable`` flag back out so OpenAPI's ``required`` field on the
+    parameter level can carry the optionality information instead.
+    """
+    schema = rust_type_to_schema(type_name)
+    if schema.get("nullable"):
+        schema = {k: v for k, v in schema.items() if k != "nullable"}
+    return schema
+
+
+def _build_operation(endpoint: Dict) -> Dict:
+    """Build one OpenAPI operation object from a single rusi endpoint."""
+    handler = endpoint.get("handler", "")
+    position = endpoint.get("position", {}) or {}
+    file_path = endpoint.get("file_path", "")
+    method = endpoint.get("method", "")
+    path = endpoint.get("path", "")
+
+    operation: Dict = {
+        "operationId": handler or f"{method}-{path}",
+        "responses": {"200": {"description": ""}},
+    }
+
+    # Line-number tracking mirrors the convention used by the JVM-style
+    # processing and the ruby converter so callers that already inspect
+    # x-atom-usages keep working.
+    line_number = position.get("line")
+    if file_path and line_number:
+        operation["x-atom-usages"] = {"call": {file_path: [line_number]}}
+
+    # Framework attribution. Carried under an x-* extension so it
+    # doesn't pollute the standard OpenAPI shape but is available to
+    # consumers that want to filter or visualise by framework.
+    if framework := endpoint.get("framework"):
+        operation["x-rust-framework"] = framework
+
+    # Dependency purl for the framework crate. Rusi populates this from
+    # cargo metadata; passing it through means consumers can correlate
+    # endpoints with the framework crate version that exposes them.
+    if purl := endpoint.get("purl"):
+        operation["x-rust-purl"] = purl
+
+    # Parameters: path and query. rusi already classifies them and
+    # gives us the Rust type as written, which we map to OpenAPI.
+    parameters = []
+    for param in endpoint.get("parameters", []):
+        name = param.get("name")
+        location = param.get("location")
+        type_name = param.get("type_name", "")
+        if not name or location not in ("path", "query"):
+            continue
+        is_optional = type_name.strip().startswith("Option<")
+        parameters.append({
+            "name": name,
+            "in": location,
+            # Path params are always required in OpenAPI; query params
+            # follow the Rust signature's optionality.
+            "required": location == "path" or not is_optional,
+            "schema": _parameter_schema(type_name),
+        })
+    if parameters:
+        operation["parameters"] = parameters
+
+    # Request body. Rust extractors only carry the body type name; the
+    # body's media-type defaults to ``application/json`` because every
+    # supported framework's body extractor (axum::Json, web::Json,
+    # rocket Json) deserialises JSON.
+    body_type = endpoint.get("request_body_type")
+    if body_type:
+        operation["requestBody"] = {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": rust_type_to_schema(body_type),
+                }
+            },
+        }
+
+    # 200 response. Skipped when we couldn't infer anything useful
+    # (e.g. handler returns plain ``StatusCode`` with no body) — the
+    # response stays as the default ``{description: ""}`` so the
+    # operation is still valid OpenAPI.
+    response_type = endpoint.get("response_type")
+    if response_type:
+        response_schema = rust_type_to_schema(response_type)
+        if response_schema and response_schema != {"type": "object"}:
+            operation["responses"]["200"]["content"] = {
+                "application/json": {
+                    "schema": response_schema,
+                }
+            }
+
+    return operation
+
+
+def convert(usages: AtomSlice) -> Dict[str, Dict]:
+    """Convert a rusi report into an OpenAPI ``paths`` dict.
+
+    Mirrors the contract of :func:`atom_tools.lib.ruby_converter.convert`
+    and :func:`atom_tools.lib.scala_converter.convert`: returns a
+    ``{path: {method: operation}}`` mapping. The caller (the
+    :class:`atom_tools.lib.converter.OpenAPI` class) wraps this into
+    the full OpenAPI document.
+    """
+    result: Dict[str, Dict] = {}
+    if not usages or not usages.content:
+        return result
+    endpoints = usages.content.get("api_endpoints", [])
+    if not endpoints:
+        return result
+
+    for endpoint in endpoints:
+        raw_path = endpoint.get("path", "")
+        path = normalize_path(raw_path)
+        if not path:
+            continue
+        method = endpoint.get("method", "").lower()
+        if not method:
+            continue
+
+        operation = _build_operation(endpoint)
+        if path not in result:
+            result[path] = {}
+        # If the same method on the same path was already populated
+        # (extremely rare — could happen if the same handler appears
+        # twice through different nested routers), merge line numbers
+        # so the call-tracking information isn't dropped.
+        existing = result[path].get(method)
+        if existing:
+            result[path][method] = _merge_operations(existing, operation)
+        else:
+            result[path][method] = operation
+
+    return result
+
+
+def _merge_operations(existing: Dict, new: Dict) -> Dict:
+    """Merge two operations registered against the same path+method.
+
+    Today this only concatenates the ``x-atom-usages.call`` line-number
+    lists so all source locations contributing to an endpoint stay
+    visible. Other fields prefer the existing entry; rusi normally
+    deduplicates identical endpoints upstream so collisions are rare.
+    """
+    merged = dict(existing)
+    new_calls = new.get("x-atom-usages", {}).get("call", {})
+    if new_calls:
+        existing_calls = merged.setdefault("x-atom-usages", {}).setdefault("call", {})
+        for file_path, line_numbers in new_calls.items():
+            bucket = existing_calls.setdefault(file_path, [])
+            for line_number in line_numbers:
+                if line_number not in bucket:
+                    bucket.append(line_number)
+    return merged

--- a/atom_tools/lib/slices.py
+++ b/atom_tools/lib/slices.py
@@ -109,6 +109,11 @@ def import_slice(filename: str | Path) -> Tuple[Dict, str, str]:
             slice_type = 'usages'
         elif 'reachables' in content:
             slice_type = 'reachables'
+        elif 'api_endpoints' in content:
+            # Rusi (cdxgen-plugins-bin) reports — Rust analyzer output.
+            # The api_endpoints array is the structured endpoint table
+            # produced by rusi's api-discovery pass.
+            slice_type = 'api_endpoints'
     except (json.decoder.JSONDecodeError, UnicodeDecodeError):
         logger.warning(
             f'Failed to load usages slice: {filename}\nPlease check that you specified a valid'

--- a/test/data/rust-axum-sample-rusi.json
+++ b/test/data/rust-axum-sample-rusi.json
@@ -1,0 +1,268 @@
+{
+  "api_endpoints": [
+    {
+      "id": "api-endpoint-213077a1e1ef9c6d",
+      "method": "GET",
+      "path": "/api/v1/users",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::users::list_users",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 7,
+        "column": 5
+      },
+      "parameters": [
+        {
+          "name": "Query(params)",
+          "location": "query",
+          "type_name": "UserListQuery"
+        }
+      ],
+      "request_body_type": null,
+      "response_type": "Vec<User>",
+      "properties": {}
+    },
+    {
+      "id": "api-endpoint-614640de83de05ed",
+      "method": "GET",
+      "path": "/health",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::health::health",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 35,
+        "column": 5
+      },
+      "parameters": [],
+      "request_body_type": null,
+      "response_type": "serde_json::Value",
+      "properties": {}
+    },
+    {
+      "id": "api-endpoint-6476823847972e4b",
+      "method": "GET",
+      "path": "/api/v1/orders/:id",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::orders::get_order",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 18,
+        "column": 5
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "location": "path",
+          "type_name": "i32"
+        }
+      ],
+      "request_body_type": null,
+      "response_type": "Order",
+      "properties": {}
+    },
+    {
+      "id": "api-endpoint-6ad513f2c8d1a1cc",
+      "method": "POST",
+      "path": "/api/v1/auth/login",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::auth::login",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 24,
+        "column": 5
+      },
+      "parameters": [],
+      "request_body_type": "LoginRequest",
+      "response_type": "LoginResponse",
+      "properties": {}
+    },
+    {
+      "id": "api-endpoint-832d671c71b6927e",
+      "method": "POST",
+      "path": "/api/v1/orders",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::orders::create_order",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 18,
+        "column": 5
+      },
+      "parameters": [],
+      "request_body_type": "CreateOrderRequest",
+      "response_type": "Order",
+      "properties": {}
+    },
+    {
+      "id": "api-endpoint-9c7f9e9bbe71d0bc",
+      "method": "GET",
+      "path": "/ready",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::health::ready",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 35,
+        "column": 5
+      },
+      "parameters": [],
+      "request_body_type": null,
+      "response_type": "serde_json::Value",
+      "properties": {}
+    },
+    {
+      "id": "api-endpoint-a00510906b73bdd0",
+      "method": "GET",
+      "path": "/api/v1/orders",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::orders::list_orders",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 18,
+        "column": 5
+      },
+      "parameters": [],
+      "request_body_type": null,
+      "response_type": "Vec<Order>",
+      "properties": {}
+    },
+    {
+      "id": "api-endpoint-a434220637508ea9",
+      "method": "POST",
+      "path": "/api/v1/users",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::users::create_user",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 7,
+        "column": 5
+      },
+      "parameters": [],
+      "request_body_type": "CreateUserRequest",
+      "response_type": "User",
+      "properties": {}
+    },
+    {
+      "id": "api-endpoint-af5bb00482908b9c",
+      "method": "PATCH",
+      "path": "/api/v1/users/:id",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::users::update_user",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 7,
+        "column": 5
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "location": "path",
+          "type_name": "i32"
+        }
+      ],
+      "request_body_type": "UpdateUserRequest",
+      "response_type": "User",
+      "properties": {}
+    },
+    {
+      "id": "api-endpoint-b705fcbc56704a65",
+      "method": "DELETE",
+      "path": "/api/v1/users/:id",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::users::delete_user",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 7,
+        "column": 5
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "location": "path",
+          "type_name": "i32"
+        }
+      ],
+      "request_body_type": null,
+      "response_type": "StatusCode",
+      "properties": {}
+    },
+    {
+      "id": "api-endpoint-ca48c86cf465942f",
+      "method": "GET",
+      "path": "/api/v1/users/:id",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::users::get_user",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 7,
+        "column": 5
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "location": "path",
+          "type_name": "i32"
+        }
+      ],
+      "request_body_type": null,
+      "response_type": "User",
+      "properties": {}
+    },
+    {
+      "id": "api-endpoint-ec8f27a00f74615c",
+      "method": "POST",
+      "path": "/api/v1/auth/logout",
+      "framework": "axum",
+      "handler": "sample_rust_api::handlers::auth::logout",
+      "package_path": "sample_rust_api",
+      "purl": "pkg:cargo/axum@0.7.9",
+      "file_path": "src/routes.rs",
+      "position": {
+        "filename": "src/routes.rs",
+        "line": 24,
+        "column": 5
+      },
+      "parameters": [],
+      "request_body_type": null,
+      "response_type": "StatusCode",
+      "properties": {}
+    }
+  ],
+  "tool": {
+    "name": "rusi",
+    "version": "2.4.0",
+    "description": "Rust source analysis inspector"
+  },
+  "schema_version": "https://appthreat.github.io/rusi/schema/report-0.1"
+}

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -1391,3 +1391,95 @@ def test_ts_custom_router_openapi(ts_usages_1):
     assert '/items' in paths
     assert '/users' in paths
     assert '/render' in paths
+
+
+@pytest.fixture
+def rust_usages_1():
+    # Real rusi report (cdxgen-plugins-bin v2.4.0+) emitted by the
+    # api-discovery pass against a small axum service: 12 endpoints
+    # nested under /api/v1 plus /health and /ready at the root.
+    return OpenAPI('openapi3.0.1', 'rust',
+                   'test/data/rust-axum-sample-rusi.json')
+
+
+def test_rust_axum_convert_emits_expected_paths(rust_usages_1):
+    """The rust converter should produce one OpenAPI path entry per
+    rusi endpoint, with framework-native placeholders (axum's ``:id``)
+    normalised to OpenAPI's ``{id}``."""
+    result = rust_usages_1.convert_usages()
+    result = sort_openapi_result(result)
+
+    expected_paths = {
+        '/health',
+        '/ready',
+        '/api/v1/users',
+        '/api/v1/users/{id}',
+        '/api/v1/orders',
+        '/api/v1/orders/{id}',
+        '/api/v1/auth/login',
+        '/api/v1/auth/logout',
+    }
+    assert set(result.keys()) == expected_paths
+
+
+def test_rust_axum_methods_per_path(rust_usages_1):
+    """All HTTP methods registered against a path should appear in
+    the converted operation map. For ``/api/v1/users/{id}`` the
+    fixture registers GET, PATCH, and DELETE."""
+    result = rust_usages_1.convert_usages()
+    user_by_id = result['/api/v1/users/{id}']
+    assert set(user_by_id.keys()) == {'get', 'patch', 'delete'}
+    users = result['/api/v1/users']
+    assert set(users.keys()) == {'get', 'post'}
+
+
+def test_rust_axum_path_param_extraction(rust_usages_1):
+    """Path parameters should be lifted out of the handler signature
+    with the correct name, location, and OpenAPI scalar schema."""
+    result = rust_usages_1.convert_usages()
+    op = result['/api/v1/users/{id}']['get']
+    params = op.get('parameters', [])
+    assert len(params) == 1
+    param = params[0]
+    assert param['name'] == 'id'
+    assert param['in'] == 'path'
+    assert param['required'] is True
+    assert param['schema'] == {'type': 'integer', 'format': 'int32'}
+
+
+def test_rust_axum_request_body_and_response_types(rust_usages_1):
+    """A handler with ``Json<CreateUserRequest>`` should map to a
+    ``requestBody`` referencing the body type via $ref; the return
+    type should appear as the 200 response content schema."""
+    result = rust_usages_1.convert_usages()
+    create_user = result['/api/v1/users']['post']
+
+    body = create_user['requestBody']
+    assert body['required'] is True
+    body_schema = body['content']['application/json']['schema']
+    assert body_schema == {'$ref': '#/components/schemas/CreateUserRequest'}
+
+    response_schema = create_user['responses']['200']['content']['application/json']['schema']
+    assert response_schema == {'$ref': '#/components/schemas/User'}
+
+
+def test_rust_axum_framework_attribution(rust_usages_1):
+    """Each operation carries the framework name and the framework
+    crate's purl so downstream tooling can correlate endpoints with
+    their dependency."""
+    result = rust_usages_1.convert_usages()
+    op = result['/api/v1/users/{id}']['get']
+    assert op.get('x-rust-framework') == 'axum'
+    purl = op.get('x-rust-purl', '')
+    assert purl.startswith('pkg:cargo/axum')
+
+
+def test_rust_axum_endpoints_to_openapi(rust_usages_1):
+    """The full OpenAPI-document export wraps the rust converter's
+    paths dict in the standard envelope."""
+    result = rust_usages_1.endpoints_to_openapi()
+    result = sort_openapi_result(result)
+    assert result['openapi'] == '3.0.1'
+    paths = result['paths']
+    assert '/health' in paths
+    assert '/api/v1/users/{id}' in paths


### PR DESCRIPTION
Adds support for converting rusi reports (the Rust analyzer in cdxgen/cdxgen-plugins-bin v2.4.0+) into OpenAPI paths via a new `rust_converter` module. Mirrors the per-language converter pattern already used for Ruby and Scala.

The rust converter reads rusi's `api_endpoints` array and produces one OpenAPI operation per endpoint. It:

- Normalises framework-native path placeholders to OpenAPI's `{name}` form (axum `:id`, actix `{id}`, rocket `<id>`).
- Maps Rust scalar types (i32/i64/u*/f*/bool/String/etc.) to the matching OpenAPI primitive schemas; unwraps `Option<T>`, `Vec<T>`, and framework `Json<T>` wrappers; emits custom types as a `$ref` pointing at `#/components/schemas/<TypeName>`.
- Carries the framework attribution (axum / actix-web / rocket) and the framework crate's purl through to the operation as `x-rust-framework` and `x-rust-purl` extensions.
- Tracks source line numbers under the existing `x-atom-usages.call` shape so consumers that already filter on call locations keep working.

Dispatch lives in `OpenAPI.convert_usages` alongside ruby and scala: `origin_type in ("rs", "rust")` routes to the new module. `slices.py` recognises rusi reports via the presence of the `api_endpoints` top-level key and assigns `slice_type = "api_endpoints"`.

Test data: a real rusi report from a small axum service (12 endpoints nested under /api/v1 plus /health and /ready) is checked in as `test/data/rust-axum-sample-rusi.json`. Six new tests cover path expectations, methods per path, path-parameter extraction, request body / response shape, framework attribution, and the full OpenAPI document export.

All 83 existing tests still pass; 6 new tests pass. No changes to existing behaviour for any other language.