### PR TITLE
feat: add Go converter that reads golem reports into OpenAPI paths

### DIFF
--- a/atom_tools/lib/converter.py
+++ b/atom_tools/lib/converter.py
@@ -21,6 +21,7 @@ from atom_tools.lib.regex_utils import (
     OpenAPIRegexCollection,
 )
 from atom_tools.lib.slices import AtomSlice
+from atom_tools.lib.go_converter import convert as go_convert
 from atom_tools.lib.ruby_converter import convert as ruby_convert
 from atom_tools.lib.rust_converter import convert as rust_convert
 from atom_tools.lib.scala_converter import convert as scala_convert
@@ -388,6 +389,8 @@ class OpenAPI:
             return scala_convert(self.usages, self.semantics)
         if self.usages.origin_type in ("rs", "rust"):
             return rust_convert(self.usages)
+        if self.usages.origin_type in ("go", "golang"):
+            return go_convert(self.usages)
         methods = self._process_methods()
         methods = self.methods_to_endpoints(methods)
         self.target_line_nums = self._identify_target_line_nums(methods)

--- a/atom_tools/lib/go_converter.py
+++ b/atom_tools/lib/go_converter.py
@@ -1,0 +1,294 @@
+"""
+Go converter helper.
+
+Consumes a golem report (produced by the ``golem`` analyzer shipped in
+``cdxgen/cdxgen-plugins-bin`` v3.0.5+) and produces an OpenAPI paths
+dict in the same shape that the JVM-style processing in
+``atom_tools.lib.converter`` does for other languages.
+
+Golem's ``apiEndpoints`` array already carries the framework, HTTP
+method, path (with any group / router-nest prefixes already merged in),
+handler function name, path/query parameters, request-body type, and
+response type. This module just translates those records into the
+OpenAPI shape atom-tools' callers expect.
+
+Path placeholders are normalised across the supported frameworks:
+
+- Gin / Echo / iris ``:id`` → OpenAPI ``{id}``.
+- chi / gorilla/mux ``{id}`` and ``{id:regex}`` → OpenAPI ``{id}``.
+- net/http ``{id}`` (Go 1.22+ pattern syntax) → OpenAPI ``{id}``.
+
+Go types from parameter and body / response positions are mapped to
+OpenAPI schemas. Common scalars, ``[]T`` slice wrappers, and framework
+ad-hoc map aliases collapse to the corresponding OpenAPI primitives.
+Custom types are emitted as a ``$ref`` pointing at
+``#/components/schemas/<TypeName>`` so downstream tooling can still
+match by type name even when the field-level schema is not (yet)
+available from the analyzer.
+"""
+
+import re
+from typing import Dict, Optional
+
+from atom_tools.lib.slices import AtomSlice
+
+
+# Map of recognised Go scalar / builtin types to OpenAPI schema dicts.
+# Anything not in here is treated as either a known wrapper (``[]T``,
+# framework map alias) or a custom type that becomes a $ref.
+_GO_SCALAR_SCHEMA: Dict[str, Dict] = {
+    "string": {"type": "string"},
+    "bool": {"type": "boolean"},
+    "int": {"type": "integer", "format": "int64"},
+    "int8": {"type": "integer", "format": "int32"},
+    "int16": {"type": "integer", "format": "int32"},
+    "int32": {"type": "integer", "format": "int32"},
+    "int64": {"type": "integer", "format": "int64"},
+    "uint": {"type": "integer", "format": "int64"},
+    "uint8": {"type": "integer", "format": "int32"},
+    "uint16": {"type": "integer", "format": "int32"},
+    "uint32": {"type": "integer", "format": "int64"},
+    "uint64": {"type": "integer", "format": "int64"},
+    "uintptr": {"type": "integer", "format": "int64"},
+    "byte": {"type": "integer", "format": "int32"},
+    "rune": {"type": "integer", "format": "int32"},
+    "float32": {"type": "number", "format": "float"},
+    "float64": {"type": "number", "format": "double"},
+    "any": {"type": "object"},
+    "interface{}": {"type": "object"},
+    "object": {"type": "object"},
+    "error": {"type": "string"},
+    "time.Time": {"type": "string", "format": "date-time"},
+    "time.Duration": {"type": "integer", "format": "int64"},
+    "uuid.UUID": {"type": "string", "format": "uuid"},
+}
+
+# Path-placeholder patterns. Golem emits the framework-native placeholder
+# verbatim, so we look for each shape and normalise to ``{name}``.
+#   Gin / Echo / iris: ``:id`` (colon prefix)
+#   chi / gorilla/mux: ``{id}`` or ``{id:regex}`` (already {}-wrapped)
+#   net/http 1.22+:    ``{id}`` (already correct — left alone)
+_PLACEHOLDER_COLON = re.compile(r":([A-Za-z_][A-Za-z0-9_]*)")
+_PLACEHOLDER_REGEX_BRACE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*):[^}]+\}")
+
+
+def normalize_path(path: str) -> str:
+    """Convert framework-native path placeholders to OpenAPI ``{name}``.
+
+    Idempotent on paths that already use ``{name}``.
+    """
+    if not path:
+        return ""
+    path = _PLACEHOLDER_COLON.sub(r"{\1}", path)
+    path = _PLACEHOLDER_REGEX_BRACE.sub(r"{\1}", path)
+    return path
+
+
+def go_type_to_schema(type_name: str) -> Dict:
+    """Map a Go type expression to an OpenAPI schema object.
+
+    Recognises common scalars, ``[]T`` slice wrappers, pointer prefixes
+    (``*T``), and framework ad-hoc map aliases (which golem already
+    collapses to ``object`` upstream). Custom types become a ``$ref``
+    so downstream consumers can match on the type name even when its
+    field structure isn't (yet) emitted by the analyzer.
+    """
+    if not type_name:
+        return {"type": "object"}
+    name = type_name.strip()
+
+    # Pointer types ``*T`` describe the same shape as T for OpenAPI.
+    while name.startswith("*"):
+        name = name[1:].lstrip()
+
+    # ``[]T`` slice / array wrapper → OpenAPI array of T.
+    if name.startswith("[]"):
+        inner = name[2:].strip()
+        return {"type": "array", "items": go_type_to_schema(inner)}
+
+    # ``map[K]V`` (rarely emitted by golem, since it collapses these
+    # upstream, but handle just in case). Fall through to free-form
+    # object; carrying the key/value types would require a nested
+    # allOf/additionalProperties schema that most OpenAPI consumers
+    # don't render usefully.
+    if name.startswith("map["):
+        return {"type": "object"}
+
+    if name in _GO_SCALAR_SCHEMA:
+        return dict(_GO_SCALAR_SCHEMA[name])
+
+    # Fall through: custom type → $ref. Strip any module path so the
+    # schema name matches what downstream tooling typically expects.
+    schema_name = name.rsplit(".", 1)[-1]
+    return {"$ref": f"#/components/schemas/{schema_name}"}
+
+
+def _parameter_schema(type_name: str) -> Dict:
+    """Schema for a path/query parameter, matching go_type_to_schema."""
+    return go_type_to_schema(type_name)
+
+
+def _endpoint_position(endpoint: Dict) -> Optional[Dict]:
+    """Golem's endpoints carry ``range.start.{filename,line,column}``
+    where rusi's carry a flat ``position``. Normalise access so the rest
+    of the module doesn't have to remember the layout difference."""
+    range_obj = endpoint.get("range") or {}
+    start = range_obj.get("start") or {}
+    if not start:
+        return None
+    return {
+        "filename": start.get("filename", ""),
+        "line": start.get("line"),
+        "column": start.get("column"),
+    }
+
+
+def _build_operation(endpoint: Dict) -> Dict:
+    """Build one OpenAPI operation object from a single golem endpoint."""
+    handler = endpoint.get("handler", "")
+    method = endpoint.get("method", "")
+    path = endpoint.get("path", "")
+    position = _endpoint_position(endpoint) or {}
+    file_path = position.get("filename", "")
+
+    operation: Dict = {
+        "operationId": handler or f"{method}-{path}",
+        "responses": {"200": {"description": ""}},
+    }
+
+    # Line-number tracking mirrors the convention used by the JVM-style
+    # processing and the ruby / rust converters so callers that already
+    # inspect x-atom-usages keep working.
+    line_number = position.get("line")
+    if file_path and line_number:
+        operation["x-atom-usages"] = {"call": {file_path: [line_number]}}
+
+    # Framework attribution. Carried under an x-* extension so it
+    # doesn't pollute the standard OpenAPI shape but is available to
+    # consumers that want to filter or visualise by framework.
+    if framework := endpoint.get("framework"):
+        operation["x-go-framework"] = framework
+
+    # Package path of the user code that registered the route. Useful
+    # for downstream tooling that groups endpoints by owning service.
+    if package_path := endpoint.get("packagePath"):
+        operation["x-go-package"] = package_path
+
+    # Parameters: path and query. Golem already classifies them and
+    # gives us the Go type as written, which we map to OpenAPI.
+    parameters = []
+    for param in endpoint.get("parameters", []) or []:
+        name = param.get("name")
+        location = param.get("location")
+        type_name = param.get("typeName", "")
+        if not name or location not in ("path", "query"):
+            continue
+        parameters.append(
+            {
+                "name": name,
+                "in": location,
+                # Path params are always required in OpenAPI; query
+                # params default to optional (Go handlers typically
+                # tolerate missing query strings).
+                "required": location == "path",
+                "schema": _parameter_schema(type_name),
+            }
+        )
+    if parameters:
+        operation["parameters"] = parameters
+
+    # Request body. Golem records only the type name; the body's
+    # media-type defaults to ``application/json`` because every
+    # supported framework binder golem detects deserialises JSON.
+    body_type = endpoint.get("requestBodyType")
+    if body_type:
+        operation["requestBody"] = {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": go_type_to_schema(body_type),
+                }
+            },
+        }
+
+    # 200 response. Skipped when the analyzer couldn't infer a body
+    # type — the response stays at the default ``{description: ""}`` so
+    # the operation is still valid OpenAPI.
+    response_type = endpoint.get("responseType")
+    if response_type:
+        response_schema = go_type_to_schema(response_type)
+        if response_schema:
+            operation["responses"]["200"]["content"] = {
+                "application/json": {
+                    "schema": response_schema,
+                }
+            }
+
+    return operation
+
+
+def convert(usages: AtomSlice) -> Dict[str, Dict]:
+    """Convert a golem report into an OpenAPI ``paths`` dict.
+
+    Mirrors the contract of :func:`atom_tools.lib.ruby_converter.convert`,
+    :func:`atom_tools.lib.rust_converter.convert`, and
+    :func:`atom_tools.lib.scala_converter.convert`: returns a
+    ``{path: {method: operation}}`` mapping. The caller (the
+    :class:`atom_tools.lib.converter.OpenAPI` class) wraps this into
+    the full OpenAPI document.
+    """
+    result: Dict[str, Dict] = {}
+    if not usages or not usages.content:
+        return result
+    endpoints = usages.content.get("apiEndpoints", [])
+    if not endpoints:
+        return result
+
+    for endpoint in endpoints:
+        # Golem also reports ``http-listener`` and ``rpc-service``
+        # entries alongside HTTP routes; only the actual routes belong
+        # in an OpenAPI ``paths`` dict.
+        if endpoint.get("kind") not in ("http-route", None, ""):
+            continue
+
+        raw_path = endpoint.get("path", "")
+        path = normalize_path(raw_path)
+        if not path:
+            continue
+        method = endpoint.get("method", "").lower()
+        if not method:
+            continue
+
+        operation = _build_operation(endpoint)
+        if path not in result:
+            result[path] = {}
+        # If the same method on the same path was already populated
+        # (rare — could happen if the same handler is registered under
+        # multiple entry points), merge line numbers so all source
+        # locations contributing to an endpoint stay visible.
+        existing = result[path].get(method)
+        if existing:
+            result[path][method] = _merge_operations(existing, operation)
+        else:
+            result[path][method] = operation
+
+    return result
+
+
+def _merge_operations(existing: Dict, new: Dict) -> Dict:
+    """Merge two operations registered against the same path+method.
+
+    Only the ``x-atom-usages.call`` line-number lists concatenate; every
+    other field prefers the existing entry, since golem normally
+    deduplicates identical endpoints upstream and true collisions carry
+    the same shape."""
+    merged = dict(existing)
+    new_calls = new.get("x-atom-usages", {}).get("call", {})
+    if new_calls:
+        existing_calls = merged.setdefault("x-atom-usages", {}).setdefault("call", {})
+        for file_path, line_numbers in new_calls.items():
+            bucket = existing_calls.setdefault(file_path, [])
+            for line_number in line_numbers:
+                if line_number not in bucket:
+                    bucket.append(line_number)
+    return merged

--- a/atom_tools/lib/slices.py
+++ b/atom_tools/lib/slices.py
@@ -114,6 +114,12 @@ def import_slice(filename: str | Path) -> Tuple[Dict, str, str]:
             # The api_endpoints array is the structured endpoint table
             # produced by rusi's api-discovery pass.
             slice_type = "api_endpoints"
+        elif "apiEndpoints" in content:
+            # Golem (cdxgen-plugins-bin) reports — Go analyzer output.
+            # Uses camelCase apiEndpoints (rather than snake_case) so
+            # it's disambiguated from rusi reports at the slice-loading
+            # layer even though converter dispatch is by origin_type.
+            slice_type = "api_endpoints"
     except (json.decoder.JSONDecodeError, UnicodeDecodeError):
         logger.warning(
             f"Failed to load usages slice: {filename}\nPlease check that you specified a valid"

--- a/test/data/go-gin-sample-golem.json
+++ b/test/data/go-gin-sample-golem.json
@@ -1,0 +1,284 @@
+{
+  "apiEndpoints": [
+    {
+      "id": "sample-gin-api|endpoint|http-route|DELETE|/api/v1/users/:id|deleteUser|/Users/abdul/golem-trial/sample-gin-api/main.go|88|4",
+      "kind": "http-route",
+      "framework": "gin",
+      "method": "DELETE",
+      "path": "/api/v1/users/:id",
+      "handler": "deleteUser",
+      "packagePath": "sample-gin-api",
+      "usageScope": "runtime",
+      "range": {
+        "start": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1952,
+          "line": 88,
+          "column": 4
+        },
+        "end": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1984,
+          "line": 88,
+          "column": 36
+        }
+      }
+    },
+    {
+      "id": "sample-gin-api|endpoint|http-route|GET|/api/v1/orders/:id|getOrder|/Users/abdul/golem-trial/sample-gin-api/main.go|95|4",
+      "kind": "http-route",
+      "framework": "gin",
+      "method": "GET",
+      "path": "/api/v1/orders/:id",
+      "handler": "getOrder",
+      "packagePath": "sample-gin-api",
+      "usageScope": "runtime",
+      "range": {
+        "start": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 2092,
+          "line": 95,
+          "column": 4
+        },
+        "end": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 2120,
+          "line": 95,
+          "column": 32
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "location": "path",
+          "typeName": "string"
+        }
+      ],
+      "responseType": "object"
+    },
+    {
+      "id": "sample-gin-api|endpoint|http-route|GET|/api/v1/orders|listOrders|/Users/abdul/golem-trial/sample-gin-api/main.go|93|4",
+      "kind": "http-route",
+      "framework": "gin",
+      "method": "GET",
+      "path": "/api/v1/orders",
+      "handler": "listOrders",
+      "packagePath": "sample-gin-api",
+      "usageScope": "runtime",
+      "range": {
+        "start": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 2030,
+          "line": 93,
+          "column": 4
+        },
+        "end": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 2056,
+          "line": 93,
+          "column": 30
+        }
+      },
+      "responseType": "[]object"
+    },
+    {
+      "id": "sample-gin-api|endpoint|http-route|GET|/api/v1/users/:id|getUser|/Users/abdul/golem-trial/sample-gin-api/main.go|86|4",
+      "kind": "http-route",
+      "framework": "gin",
+      "method": "GET",
+      "path": "/api/v1/users/:id",
+      "handler": "getUser",
+      "packagePath": "sample-gin-api",
+      "usageScope": "runtime",
+      "range": {
+        "start": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1887,
+          "line": 86,
+          "column": 4
+        },
+        "end": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1913,
+          "line": 86,
+          "column": 30
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "location": "path",
+          "typeName": "string"
+        }
+      ],
+      "responseType": "object"
+    },
+    {
+      "id": "sample-gin-api|endpoint|http-route|GET|/api/v1/users|listUsers|/Users/abdul/golem-trial/sample-gin-api/main.go|84|4",
+      "kind": "http-route",
+      "framework": "gin",
+      "method": "GET",
+      "path": "/api/v1/users",
+      "handler": "listUsers",
+      "packagePath": "sample-gin-api",
+      "usageScope": "runtime",
+      "range": {
+        "start": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1829,
+          "line": 84,
+          "column": 4
+        },
+        "end": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1853,
+          "line": 84,
+          "column": 28
+        }
+      },
+      "responseType": "[]User"
+    },
+    {
+      "id": "sample-gin-api|endpoint|http-route|GET|/health|health|/Users/abdul/golem-trial/sample-gin-api/main.go|78|2",
+      "kind": "http-route",
+      "framework": "gin",
+      "method": "GET",
+      "path": "/health",
+      "handler": "health",
+      "packagePath": "sample-gin-api",
+      "usageScope": "runtime",
+      "range": {
+        "start": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1735,
+          "line": 78,
+          "column": 2
+        },
+        "end": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1759,
+          "line": 78,
+          "column": 26
+        }
+      },
+      "responseType": "object"
+    },
+    {
+      "id": "sample-gin-api|endpoint|http-route|PATCH|/api/v1/users/:id|updateUser|/Users/abdul/golem-trial/sample-gin-api/main.go|87|4",
+      "kind": "http-route",
+      "framework": "gin",
+      "method": "PATCH",
+      "path": "/api/v1/users/:id",
+      "handler": "updateUser",
+      "packagePath": "sample-gin-api",
+      "usageScope": "runtime",
+      "range": {
+        "start": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1917,
+          "line": 87,
+          "column": 4
+        },
+        "end": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1948,
+          "line": 87,
+          "column": 35
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "location": "path",
+          "typeName": "string"
+        }
+      ],
+      "responseType": "object"
+    },
+    {
+      "id": "sample-gin-api|endpoint|http-route|POST|/api/v1/auth/login|login|/Users/abdul/golem-trial/sample-gin-api/main.go|98|3",
+      "kind": "http-route",
+      "framework": "gin",
+      "method": "POST",
+      "path": "/api/v1/auth/login",
+      "handler": "login",
+      "packagePath": "sample-gin-api",
+      "usageScope": "runtime",
+      "range": {
+        "start": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 2128,
+          "line": 98,
+          "column": 3
+        },
+        "end": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 2158,
+          "line": 98,
+          "column": 33
+        }
+      },
+      "responseType": "object"
+    },
+    {
+      "id": "sample-gin-api|endpoint|http-route|POST|/api/v1/orders|createOrder|/Users/abdul/golem-trial/sample-gin-api/main.go|94|4",
+      "kind": "http-route",
+      "framework": "gin",
+      "method": "POST",
+      "path": "/api/v1/orders",
+      "handler": "createOrder",
+      "packagePath": "sample-gin-api",
+      "usageScope": "runtime",
+      "range": {
+        "start": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 2060,
+          "line": 94,
+          "column": 4
+        },
+        "end": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 2088,
+          "line": 94,
+          "column": 32
+        }
+      },
+      "responseType": "object"
+    },
+    {
+      "id": "sample-gin-api|endpoint|http-route|POST|/api/v1/users|createUser|/Users/abdul/golem-trial/sample-gin-api/main.go|85|4",
+      "kind": "http-route",
+      "framework": "gin",
+      "method": "POST",
+      "path": "/api/v1/users",
+      "handler": "createUser",
+      "packagePath": "sample-gin-api",
+      "usageScope": "runtime",
+      "range": {
+        "start": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1857,
+          "line": 85,
+          "column": 4
+        },
+        "end": {
+          "filename": "/Users/abdul/golem-trial/sample-gin-api/main.go",
+          "offset": 1883,
+          "line": 85,
+          "column": 30
+        }
+      },
+      "requestBodyType": "CreateUserRequest",
+      "responseType": "User",
+      "properties": {
+        "errorResponseType": "object"
+      }
+    }
+  ],
+  "tool": {
+    "name": "golem",
+    "version": "3.0.0",
+    "description": "Go Library Evidence Mapper: semantic Go source evidence and call graph analyzer"
+  },
+  "schemaVersion": "https://cdxgen.github.io/cdxgen-plugins-bin/golem/schema/v6"
+}

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -1615,3 +1615,116 @@ def test_rust_axum_endpoints_to_openapi(rust_usages_1):
     paths = result["paths"]
     assert "/health" in paths
     assert "/api/v1/users/{id}" in paths
+
+
+@pytest.fixture
+def go_usages_1():
+    # Real golem report (cdxgen-plugins-bin v3.0.5+) emitted by golem's
+    # enriched endpoint discovery against a small Gin service: 10
+    # endpoints across /health, /api/v1/users, /api/v1/orders, and
+    # /api/v1/auth/login. The fixture exercises the empty-path Group
+    # fix (POST/GET /api/v1/users have empty-string path args in the
+    # source) and the handler-signature enrichment (path params,
+    # request bodies, response types).
+    return OpenAPI("openapi3.0.1", "go", "test/data/go-gin-sample-golem.json")
+
+
+def test_go_gin_convert_emits_expected_paths(go_usages_1):
+    """The go converter should produce one OpenAPI path entry per
+    golem endpoint, with framework-native placeholders (Gin's
+    ``:id``) normalised to OpenAPI's ``{id}``."""
+    result = go_usages_1.convert_usages()
+    result = sort_openapi_result(result)
+    expected_paths = {
+        "/health",
+        "/api/v1/users",
+        "/api/v1/users/{id}",
+        "/api/v1/orders",
+        "/api/v1/orders/{id}",
+        "/api/v1/auth/login",
+    }
+    assert expected_paths.issubset(set(result.keys()))
+
+
+def test_go_gin_methods_per_path(go_usages_1):
+    """All HTTP methods registered against a path should appear in
+    the converted operation map."""
+    result = go_usages_1.convert_usages()
+    users = result["/api/v1/users"]
+    assert {"get", "post"}.issubset(set(users.keys()))
+
+
+def test_go_gin_path_param_extraction(go_usages_1):
+    """Golem lifts ``c.Param("id")`` out of getUser's body into a
+    structured parameter; the converter should emit it as an OpenAPI
+    path parameter with the correct name and location."""
+    result = go_usages_1.convert_usages()
+    op = result["/api/v1/users/{id}"]["get"]
+    params = op.get("parameters", [])
+    id_params = [p for p in params if p["name"] == "id" and p["in"] == "path"]
+    assert id_params, f"expected 'id' path parameter, got {params}"
+    assert id_params[0]["required"] is True
+    assert id_params[0]["schema"] == {"type": "string"}
+
+
+def test_go_gin_request_body_and_response_types(go_usages_1):
+    """A handler with ``c.ShouldBindJSON(&req)`` should map to a
+    ``requestBody`` referencing the body type via $ref; the return
+    type should appear as the 200 response content schema."""
+    result = go_usages_1.convert_usages()
+    create_user = result["/api/v1/users"]["post"]
+
+    body = create_user["requestBody"]
+    assert body["required"] is True
+    body_schema = body["content"]["application/json"]["schema"]
+    assert body_schema == {"$ref": "#/components/schemas/CreateUserRequest"}
+
+    response_schema = create_user["responses"]["200"]["content"]["application/json"]["schema"]
+    # POST /api/v1/users returns a User struct via c.JSON(201, User{...}).
+    assert response_schema == {"$ref": "#/components/schemas/User"}
+
+
+def test_go_gin_slice_response_preserves_multiplicity(go_usages_1):
+    """A handler returning ``[]User`` should map to an OpenAPI array
+    of Users, not a single User reference."""
+    result = go_usages_1.convert_usages()
+    list_users = result["/api/v1/users"]["get"]
+    response_schema = list_users["responses"]["200"]["content"]["application/json"]["schema"]
+    assert response_schema == {
+        "type": "array",
+        "items": {"$ref": "#/components/schemas/User"},
+    }
+
+
+def test_go_gin_framework_attribution(go_usages_1):
+    """Each operation carries the detected framework and the owning
+    Go package so downstream tooling can group endpoints by service."""
+    result = go_usages_1.convert_usages()
+    op = result["/api/v1/users/{id}"]["get"]
+    assert op.get("x-go-framework") == "gin"
+    assert op.get("x-go-package")
+
+
+def test_go_gin_gin_h_maps_to_free_form_object(go_usages_1):
+    """Handlers that return ``gin.H{...}`` (an ad-hoc map alias)
+    should surface as a free-form ``object`` schema rather than a
+    $ref to something with no declaration to point at. Golem
+    collapses gin.H to ``object`` upstream; the converter has to
+    pass that through as an OpenAPI object type."""
+    result = go_usages_1.convert_usages()
+    health = result["/health"]["get"]
+    response = health["responses"]["200"]
+    if "content" in response:
+        schema = response["content"]["application/json"]["schema"]
+        assert schema == {"type": "object"}
+
+
+def test_go_gin_endpoints_to_openapi(go_usages_1):
+    """The full OpenAPI-document export wraps the go converter's
+    paths dict in the standard envelope."""
+    result = go_usages_1.endpoints_to_openapi()
+    result = sort_openapi_result(result)
+    assert result["openapi"] == "3.0.1"
+    paths = result["paths"]
+    assert "/health" in paths
+    assert "/api/v1/users/{id}" in paths


### PR DESCRIPTION
Adds support for converting golem reports (the Go analyser in cdxgen/cdxgen-plugins-bin v3.0.5+) into OpenAPI paths via a new `go_converter` module. Mirrors the per-language converter pattern already used for Ruby, Scala, and Rust.

The go converter reads golem's `apiEndpoints` array and produces one OpenAPI operation per endpoint. It:

- Normalises framework-native path placeholders to OpenAPI's `{name}` form (Gin/Echo/iris `:id`, chi/gorilla-mux `{id}` and `{id:regex}`, net/http 1.22+ `{id}`).
- Maps Go scalar types (string/int*/uint*/float*/bool/byte/rune, plus common stdlib types like time.Time and uuid.UUID) to the matching OpenAPI primitive schemas; unwraps `*T` pointers and `[]T` slices; treats `any`/`interface{}`/`map[K]V` as free-form objects. Custom types become a `$ref` pointing at `#/components/schemas/<TypeName>` so downstream tooling can match by type name even when the field-level schema isn't available.
- Carries the framework attribution (gin / chi / echo / net/http / grpc / …) and the owning Go package through as `x-go-framework` and `x-go-package` extensions on each operation, so downstream tooling can group endpoints by service.
- Tracks source line numbers under the existing `x-atom-usages.call` shape so consumers that already filter on call locations keep working.
- Skips non-`http-route` entries from golem (its `http-listener` and `rpc-service` kinds don't belong in an OpenAPI paths dict).

Dispatch lives in `OpenAPI.convert_usages` alongside ruby / scala / rust: `origin_type in ("go", "golang")` routes to the new module. `slices.py` recognises golem reports via the presence of the camelCase `apiEndpoints` top-level key and reuses the `api_endpoints` slice_type from rusi so downstream tooling that filters by slice type doesn't need per-analyser variants.

Test data: a real golem report from a small Gin service (10 endpoints across /health, /api/v1/{users,orders,auth/login}) is checked in as `test/data/go-gin-sample-golem.json`. Eight new tests cover path expectations, methods per path, path-parameter extraction, request body / response shape, slice-response multiplicity, framework attribution, ad-hoc-map (gin.H) collapse to `object`, and the full OpenAPI document export.

All 106 existing tests still pass; 8 new tests pass. No changes to existing behaviour for any other language.